### PR TITLE
ホスト名の制限を設定した

### DIFF
--- a/config/initializers/blocked_hosts.rb
+++ b/config/initializers/blocked_hosts.rb
@@ -1,0 +1,5 @@
+Rails.application.configure do
+# You can use blocked_hosts.rb to restrict domain names from rails6
+  config.hosts << "example.com"
+  config.hosts << "origin.example.com"
+end


### PR DESCRIPTION
* railsアプリケーションにアクセスする際に使用できるホスト（ドメイン）名「example.com」「origin.example.com」をホワイトリストに追加する
* 制限が不要であればconfig.hosts = nilに設定変更でblocked_hostsを無効可出来る