### PR TITLE
500エラー画面を変更した

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,38 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
+ * vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
+ * files in this directory. Styles in this file should be added after the last require_* statement.
+ * It is generally better to create a new file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ */
+
+/* グレー系 */
+
+$dark_gray: #666666;
+$gray: #cccccc;
+$light_gray: #eeeeee;
+$very_light_gray: #fafafa;
+
+/* 赤系 */
+
+$red: #B00100;
+
+
+div#error {
+  width: 600px;
+  margin: 20px auto;
+  padding: 20px;
+  border-radius: 25px;
+  border: solid 4px $dark_gray;
+  background-color: $very_light_gray;
+  text-align: center;
+  color: $red;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,0 +1,7 @@
+class ApplicationController < ActionController::Base
+  rescue_from StandardError, with: :rescue500
+
+  private def rescue500
+    render "errors/internal_server_error", status: 500
+  end
+end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,4 @@
+<div id="error">
+  <h1>500 Internal Server Error</h1>
+  <p>ごめんね( *´艸｀)。システムエラーが発生したよ？。</p>
+</div>


### PR DESCRIPTION
* view/errors/internal_server_error.html.erbを追加しエラー時の表示を変更
* スタイルシートのerrorのスタイルを追加
* application_controller.rbに例外を補足する記述を追加
 - +2rescue_formでStandardErrorの例外（子孫含む）発生時rescue500に処理が移行する
 - +4privateとしてrescueの処理を追加
 - +5上記追加したviewにrenderするよう設定
 - +5status: 500 にてHTTPレスポンスのステータスコードを500に設定