### PR TITLE
403エラー画面を変更した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,22 @@
 class ApplicationController < ActionController::Base
-  rescue_from StandardError, with: :rescue500
 
-  private def rescue500
-    render "errors/internal_server_error", status: 500
+  class Forbidden < ActionController::ActionControllerError; end
+  class IpAddressRejected < ActionController::ActionControllerError; end
+
+  rescue_from StandardError, with: :rescue500
+  rescue_from ApplicationController::Forbidden, with: :rescue403
+  rescue_from ApplicationController::IpAddressRejected, with: :rescue403
+
+
+  private def rescue403(e)
+    @exception = e
+    render "errors/forbidden", status: 403
+    # 403は要求されらリソースがwebサイトに存在するがなんらかの理由でアクセス拒否された時
   end
+
+  private def rescue500(e)
+    render "errors/internal_server_error", status: 500
+    #　500は何らかのエラーが発生してる時
+  end
+  # ActionController::ActionControllerError < StandardError < Exception
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,13 @@
+<div id="error">
+  <h1>403 Forbidden</h1>
+  <p>
+    <%=
+      case @exception
+      when ApplicationController::IpAddressRejected
+        "君のIPアドレス（#{request.ip}）からは利用できないぞっ！( *´艸｀)。"
+      else
+        "あれ？ページを閲覧する権限がないよ？( *´艸｀)。"
+      end
+    %>
+  </p>
+</div>


### PR DESCRIPTION
* view/errors/forbidden_error.html.erbを追加しエラー時の表示を変更
 - @exceptionで引数に渡された（e）例外オブジェクトの種類によって表示を切り替えるようcase文を追加
* application_controller.rbに例外を補足する記述を追加
 - +3class Forbiddenを定義
 - +4class IpAddressRejectedを定義
 - +7rescue_formで上記の例外発生時rescue403に処理が移行する
 - +8rescue_formで上記の例外発生時rescue403に処理が移行する
 - +11~privateとしてrescueの処理を追加 上記追加したviewにrenderするよう設定 status: 403 にてHTTPレスポンスのステータスコードを403に設定
 - 継承関係、エラーステータス説明コメント#を追加